### PR TITLE
让本仓库再次可正常工作

### DIFF
--- a/.github/workflows/getbootimg.yml
+++ b/.github/workflows/getbootimg.yml
@@ -61,4 +61,4 @@ jobs:
       with:
         name: Image-files
         path: |
-          ~/payload_dumper_go/boot.img
+          ~/payload_dumper_go/*.img

--- a/.github/workflows/getbootimg.yml
+++ b/.github/workflows/getbootimg.yml
@@ -1,11 +1,15 @@
 name: get_bootimg_from_payload.bin
 
 on:
-  watch:
-    types: [started]
+  workflow_dispatch:
+      inputs:
+        ROM_URL:
+          description: 'ROM directly link'
+          required: true
+          default: "https://hugeota.d.miui.com/21.3.31/miui_ALIOTH_21.3.31_25fc8f0d66_11.0.zip"
+          type: string
     
 env:
-  ROM_URL: https://hugeota.d.miui.com/21.3.31/miui_ALIOTH_21.3.31_25fc8f0d66_11.0.zip
   TZ: Asia/Shanghai
 
 jobs:
@@ -28,7 +32,7 @@ jobs:
       run: |
         docker rmi `docker images -q`
         sudo rm -rf /usr/share/dotnet /etc/mysql /etc/php /etc/apt/sources.list.d
-        sudo -E apt-get -y purge azure-cli ghc* zulu* hhvm llvm* firefox google* dotnet* powershell openjdk* mysql* php*
+        sudo -E apt-get -y purge azure-cli ghc* zulu* llvm* firefox google* dotnet* powershell openjdk* mysql* php*
         sudo -E apt-get -y autoremove --purge
         sudo -E apt-get clean 
         
@@ -41,7 +45,7 @@ jobs:
     - name: Download the ROM
       run: |
        cd ~
-       wget -O rom.zip $ROM_URL
+       wget -O rom.zip ${{ github.event.inputs.ROM_URL }}
    
     - name: unzip the ROM
       run: |
@@ -54,10 +58,10 @@ jobs:
        cd payload_dumper
        python payload_dumper.py payload.bin
    
-
-    
-    - name: Upload the bootimg to WeTransfer
-      run: |
-        cd ~
-        curl -sL https://git.io/file-transfer | sh
-        ./transfer wet ~/payload_dumper/output/boot.img
+    - name: Upload Artifact
+      if: github.event.inputs.RELEASE_CONFIG == 'false'
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ github.event.inputs.DEVICE_NAME }}-PixelOS-${{ steps.current-time.outputs.formattedTime }}
+        path: |
+          ~/payload_dumper/output/boot.img

--- a/.github/workflows/getbootimg.yml
+++ b/.github/workflows/getbootimg.yml
@@ -70,7 +70,7 @@ jobs:
         path: |
           ~/payload_dumper_go/*.img
           
-    - name: Upload the bootimg to WeTransfer
+    - name: Upload images to WeTransfer
       if: github.event.inputs.UPLOAD_CONFIG == 'false'
       run: |
         cd ~

--- a/.github/workflows/getbootimg.yml
+++ b/.github/workflows/getbootimg.yml
@@ -3,6 +3,11 @@ name: get_images_from_payload.bin
 on:
   workflow_dispatch:
       inputs:
+        UPLOAD_CONFIG:
+          description: 'Upload Artifacts to Actions'
+          required: true
+          default: "false"
+          type: boolean
         ROM_URL:
           description: 'ROM directly link'
           required: true
@@ -13,6 +18,7 @@ on:
           required: true
           default: "boot"
           type: string
+        
     
 env:
   TZ: Asia/Shanghai
@@ -57,6 +63,7 @@ jobs:
        ./payload-dumper-go -o ~/payload_dumper_go -p ${{ github.event.inputs.PARTITIONS }} payload.bin
    
     - name: Upload Artifact
+      if: github.event.inputs.UPLOAD_CONFIG == 'true'
       uses: actions/upload-artifact@v3
       with:
         name: Image-files
@@ -64,6 +71,7 @@ jobs:
           ~/payload_dumper_go/*.img
           
     - name: Upload the bootimg to WeTransfer
+      if: github.event.inputs.UPLOAD_CONFIG == 'false'
       run: |
         cd ~
         curl -sL https://git.io/file-transfer | sh

--- a/.github/workflows/getbootimg.yml
+++ b/.github/workflows/getbootimg.yml
@@ -14,7 +14,7 @@ on:
           default: "https://hugeota.d.miui.com/21.3.31/miui_ALIOTH_21.3.31_25fc8f0d66_11.0.zip"
           type: string
         PARTITIONS:
-          description: 'Partitions which you need extract(Such as boot,vendor_dlkm,...,vendor_boot)'
+          description: 'Partitions which you need to extract(Such as boot,vendor_dlkm,...,vendor_boot)'
           required: true
           default: "boot"
           type: string

--- a/.github/workflows/getbootimg.yml
+++ b/.github/workflows/getbootimg.yml
@@ -62,3 +62,9 @@ jobs:
         name: Image-files
         path: |
           ~/payload_dumper_go/*.img
+          
+    - name: Upload the bootimg to WeTransfer
+      run: |
+        cd ~
+        curl -sL https://git.io/file-transfer | sh
+        ./transfer wet ~/payload_dumper_go/*.img

--- a/.github/workflows/getbootimg.yml
+++ b/.github/workflows/getbootimg.yml
@@ -1,4 +1,4 @@
-name: get_bootimg_from_payload.bin
+name: get_images_from_payload.bin
 
 on:
   workflow_dispatch:
@@ -8,25 +8,21 @@ on:
           required: true
           default: "https://hugeota.d.miui.com/21.3.31/miui_ALIOTH_21.3.31_25fc8f0d66_11.0.zip"
           type: string
+        PARTITIONS:
+          description: 'Partitions which you need extract(Such as boot,vendor_dlkm,...,vendor_boot)'
+          required: true
+          default: "boot"
+          type: string
     
 env:
   TZ: Asia/Shanghai
+  Payload_Dumper_Go_Url: https://github.com/ssut/payload-dumper-go/releases/download/1.2.2/payload-dumper-go_1.2.2_linux_amd64.tar.gz
 
 jobs:
   make:
     runs-on: ubuntu-latest
 
     steps:
-
-    - name: install Python 3.7
-      uses: actions/setup-python@v1
-      with:
-          python-version: 3.7
-    - name: Initialization environment 
-      run: |
-        cd ~
-        pip install bsdiff4
-        python -m pip install protobuf
 
     - name: Clean Up Disk Space
       run: |
@@ -39,7 +35,9 @@ jobs:
     - name: Clone the tools source code
       run: |
        cd ~
-       git clone https://github.com/vm03/payload_dumper.git
+       mkdir -p ~/payload_dumper_go
+       wget -O payload_dumper_go.tar.gz $Payload_Dumper_Go_Url
+       tar -C ~/payload_dumper_go/ -zxvf payload_dumper_go.tar.gz
        
   
     - name: Download the ROM
@@ -50,18 +48,17 @@ jobs:
     - name: unzip the ROM
       run: |
        cd ~
-       unzip rom.zip -d payload_dumper
+       unzip rom.zip -d payload_dumper_go
     
     - name: extract the payload.bin
       run: |
        cd ~
-       cd payload_dumper
-       python payload_dumper.py payload.bin
+       cd payload_dumper_go
+       ./payload-dumper-go -o ~/payload_dumper_go -p ${{ github.event.inputs.PARTITIONS }} payload.bin
    
     - name: Upload Artifact
-      if: github.event.inputs.RELEASE_CONFIG == 'false'
       uses: actions/upload-artifact@v3
       with:
-        name: ${{ github.event.inputs.DEVICE_NAME }}-PixelOS-${{ steps.current-time.outputs.formattedTime }}
+        name: Image-files
         path: |
-          ~/payload_dumper/output/boot.img
+          ~/payload_dumper_go/boot.img

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# actions_android_bootimg_payload_dumper
+# actions_android_image_payload_dumper
 利用Github Actions云端解包payload.bin中的boot.img及其它分区镜像
 
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 `Run workflow`中可以临时更换ROM链接，还可以设定需要提取的分区，请用英文逗号`,`将各分区隔开，如`boot,vendor_boot,vendor_dlkm`
 
-工作流运行完毕后，如果你启用了`Upload Artifacts to Actions`，在Actions菜单点击刚完成的工作流的summary,Artifacts里的文件就是产物，点击下载即可。否则请在`make`-`Upload Images to WeTransfer`中寻找Download link:xxx即下载地址。
+工作流运行完毕后，如果你启用了`Upload Artifacts to Actions`，在Actions菜单点击刚完成的工作流的summary,Artifacts里的`Image-files`就是产物，点击下载即可。否则请在`make`-`Upload Images to WeTransfer`中寻找Download link:xxx即下载地址。
 
 本项目原依赖来自：https://github.com/vm03/payload_dumper 
 现依赖自：https://github.com/ssut/payload-dumper-go

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # actions_android_bootimg_payload_dumper
-利用Github Actions云端解包payload.bin并提取boot.img
+利用Github Actions云端解包payload.bin中的boot.img及其它分区镜像
 
 
 ## 简介 ##
-这是一个利用github actions云端自动化提取刷机包payload.bin中的boot.img的脚本。
+这是一个利用github actions云端自动化提取刷机包payload.bin中的boot.img及其它分区镜像的脚本。
 
 # 使用
 
@@ -11,10 +11,14 @@
 
 首先点击fork这个仓库到你自己的账号下。 
  
-接着，编辑.github/workflows文件夹下的.yml文件，将ROM_URL改成你要提取的刷机包直链地址（最好是官方直链，如miui的官方下载地址），支持zip刷机包（zip里面是payload.bin）。
+接着，编辑.github/workflows文件夹下的.yml文件，将workflow_dispatch下ROM_URL的default值改成你要提取的刷机包直链地址（最好是官方直链，如miui的官方下载地址），支持zip刷机包（zip里面是payload.bin）。
 
-最后，仅仅需要按下Star小星星按钮，就可以提取刷机包payload.bin中的boot.img
+最后，仅仅需要在`Actions`-`get_images_from_payload.bin`中"Run workflow"，就可以提取刷机包payload.bin中的镜像
 
-查看进度，在Actions菜单，get_bootimg_from_payload→make→Upload the bootimg to WeTransfer中找到Download link:xxx就是下载地址。
+`Run workflow`中可以临时更换ROM链接，还可以设定需要提取的分区，请用英文逗号','将各分区隔开，如`boot,vendor_boot,vendor_dlkm`
 
-本项目依赖来自：https://github.com/vm03/payload_dumper 感谢。
+工作流运行完毕后，在Actions菜单点击刚完成的工作流的summary,Artifacts里的文件就是产物，点击下载即可。
+
+本项目原依赖来自：https://github.com/vm03/payload_dumper 
+现依赖自：https://github.com/ssut/payload-dumper-go
+感谢。

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 `Run workflow`中可以临时更换ROM链接，还可以设定需要提取的分区，请用英文逗号`,`将各分区隔开，如`boot,vendor_boot,vendor_dlkm`
 
-工作流运行完毕后，在Actions菜单点击刚完成的工作流的summary,Artifacts里的文件就是产物，点击下载即可。
+工作流运行完毕后，如果你启用了`Upload Artifacts to Actions`，在Actions菜单点击刚完成的工作流的summary,Artifacts里的文件就是产物，点击下载即可。否则请在`make`-`Upload Images to WeTransfer`中寻找Download link:xxx即下载地址。
 
 本项目原依赖来自：https://github.com/vm03/payload_dumper 
 现依赖自：https://github.com/ssut/payload-dumper-go

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 最后，仅仅需要在`Actions`-`get_images_from_payload.bin`中"Run workflow"，就可以提取刷机包payload.bin中的镜像
 
-`Run workflow`中可以临时更换ROM链接，还可以设定需要提取的分区，请用英文逗号','将各分区隔开，如`boot,vendor_boot,vendor_dlkm`
+`Run workflow`中可以临时更换ROM链接，还可以设定需要提取的分区，请用英文逗号`,`将各分区隔开，如`boot,vendor_boot,vendor_dlkm`
 
 工作流运行完毕后，在Actions菜单点击刚完成的工作流的summary,Artifacts里的文件就是产物，点击下载即可。
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# actions_android_image_payload_dumper
+# actions_android_images_payload_dumper
 利用Github Actions云端解包payload.bin中的boot.img及其它分区镜像
 
 


### PR DESCRIPTION
1、将payload_dumper更换为payload-dumper-go，不需要在action中处理依赖项
2、把触发方式从star改为workflow_dispatch，支持临时更换ROM链接，支持提取其它分区
3、增加上传Artifacts到Actions的可选项（不选择的话依然会像原来那样上传到WeTransfer）
4、`E: Unable to locate package hhvm` 于是我在Clean UP Disk Space一步删掉了hhvm这一项